### PR TITLE
Attempted to call Alarm.getTime() on a null object. The issue lies with the Parceler library and how new Alarm objects are set. It was calling Alarm.setEnabled which calls Alarm.updateTime() while time is Null. It would then try to call Alarm.setTime(). After finding the cause it turns out Alarm.updateTime() doesn't need to be called during setEnabled().

### DIFF
--- a/app/src/main/java/com/rva/mrb/vivify/Model/Data/Alarm.java
+++ b/app/src/main/java/com/rva/mrb/vivify/Model/Data/Alarm.java
@@ -76,9 +76,9 @@ public class Alarm extends RealmObject {
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-        if (isEnabled()) {
-            updateTime();
-        }
+//        if (isEnabled()) {
+//            updateTime();
+//        }
     }
 
     private void clearTime() {


### PR DESCRIPTION
Attempted to call Alarm.getTime() on a null object. The issue lies with the Parceler library and how new Alarm objects are set. It was calling Alarm.setEnabled which calls Alarm.updateTime() while time is Null. It would then try to call Alarm.setTime(). After finding the cause it turns out Alarm.updateTime() doesn't need to be called during setEnabled().